### PR TITLE
Release v2.0.0: Introduce theming and CSS class renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+## 2.0.0
+
+### Breaking
+
+- CSS classes renamed with `pun-` prefix (see README migration table).
+- Weekend / day cell classes: `currentMonth` → `pun-dayCell`, `saturday` → `pun-saturday`, `sunday` → `pun-sunday`.
+- State classes: `today` → `pun-today`, `selected` → `pun-selected`.
+
+### Added
+
+- macOS-inspired default theme with CSS custom properties on `.pun-root`.
+- Light, dark, and auto (`prefers-color-scheme`) themes via `options.theme` and `data-pun-theme`.
+- `options.classNames` for extra classes on root, table, nav, and day buttons.
+- Exported types `CalendarTheme`, `CalendarClassNames`.
+
+### Changed
+
+- Visual design: softer shadows, system blue accent, ghost navigation buttons.
+- Mount element receives `pun-root` automatically.
+
+## 1.1.1 and earlier
+
+See git history for prior releases.

--- a/FEATURE_BACKLOG.md
+++ b/FEATURE_BACKLOG.md
@@ -1,7 +1,7 @@
 # Feature backlog — PickUpNewDate
 
 Roadmap after the TypeScript migration and API improvements (development plan).  
-Status legend: **done** = available in the current library release.
+Status legend: **done** = available in the current library release (**v2.0.0+** for styling/theming; see [CHANGELOG.md](CHANGELOG.md) for breaking CSS class renames).
 
 ## Implemented (current)
 
@@ -12,11 +12,11 @@ Features available in source and in the published `pickupnewdate` package:
 | View | Month grid (Monday-first week) | `getMonthGrid`, `Calendar.render` |
 | View | Previous / next month navigation | `prevMonth`, `nextMonth`, ‹ › buttons |
 | View | Year range **1–9999** on navigation | `canGoPrev`, `canGoNext`, disabled buttons at bounds |
-| View | **Today** highlight | `.today` class, `aria-current="date"` |
-| View | Weekend styling | `.saturday`, `.sunday` classes |
+| View | **Today** highlight | `.pun-today` class, `aria-current="date"` |
+| View | Weekend styling | `.pun-saturday`, `.pun-sunday` classes |
 | Selection | `onDateSelect` callback | local `Date` object |
 | Selection | **`initialDate`** — starting month and selected day | constructor option |
-| Selection | **Selected date** state in UI | `selectedDate`, `.selected`, `aria-selected` |
+| Selection | **Selected date** state in UI | `selectedDate`, `.pun-selected`, `aria-selected` |
 | Selection | `getSelectedDate()` | returns a copy of the selected date |
 | Instance API | `goToDate(year, month, day?)` | navigate + optional day selection |
 | Instance API | `destroy()` | removes listeners and clears mount node |
@@ -30,17 +30,23 @@ Features available in source and in the published `pickupnewdate` package:
 | Distribution | ESM, CJS, UMD + CSS | Rollup, `pickupnewdate/style.css` |
 | Distribution | TypeScript sources `.ts`, declarations in `dist/*.d.ts` | strict mode |
 | Accessibility | `role="grid"`, ARIA labels on nav and days | |
-| Accessibility | **`aria-live`** on month change | `.calendarLiveRegion` |
+| Accessibility | **`aria-live`** on month change | `.pun-liveRegion` |
 | Accessibility | Keyboard: ←/→ change month (including when a day is focused) | capture on root |
 | Accessibility | Keyboard: arrow keys between days in the grid | when a day button is focused |
-| Accessibility | `:focus-visible` on buttons | `style.css` |
+| Accessibility | `:focus-visible` on buttons | `.pun-navButton`, `.pun-dayButton` in `style.css` |
 | Accessibility | `prefers-reduced-motion` | disables transition animations |
 | Security | `textContent` / `setAttribute`, no `innerHTML` | |
 | Security | Frozen dictionaries (`deepFreeze`) | |
 | Styling | Responsive layout (`max-width: 640px`) | |
-| Styling | Component-scoped styles (no global `body` rules) | font on `table.calendar` |
+| Styling | macOS-inspired design tokens + `pun-` namespace | `.pun-root`, CSS variables |
+| Styling | Light / dark / auto theme | `options.theme`, `data-pun-theme`, `prefers-color-scheme` |
+| Styling | `classNames` hook for frameworks | `CalendarOptions.classNames` |
+| Styling | Component-scoped styles (no global `body` rules) | tokens on `.pun-root` |
+| Styling | Empty grid cells | `.pun-emptyDay` (non-interactive padding cells) |
+| Styling | `color-scheme` on mount | `light dark` on `.pun-root` for native form controls |
+| API | Theme + class hook types | exported `CalendarTheme`, `CalendarClassNames` |
 
-Full API description and examples: [README.md](README.md).
+Full API description and examples: [README.md](README.md). Migration **1.x → 2.0**: README *Migrating* section.
 
 ---
 
@@ -56,9 +62,10 @@ Full API description and examples: [README.md](README.md).
 | P2 | Time picker | planned | Medium |
 | P2 | Locale via `Intl` | planned | Medium |
 | P2 | RTL (`dir="rtl"`) | planned | Medium |
-| P2 | Dark mode / CSS variables | planned (partial: `prefers-reduced-motion` done) | Low–medium |
 | P2 | Touch swipe | planned | Medium |
-| P2 | Storybook / playground | planned | Medium |
+| P2 | Storybook / playground | planned (demo: [`index.html`](index.html); no Storybook yet) | Medium |
+| P2 | Minified CSS export (`style.min.css`) | planned | Low |
+| P2 | Optional Tailwind preset package | planned | Medium |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The calendar. It's not complicated. It has to be simple. That's all.
 
-Lightweight **monthly date picker** written in TypeScript, CSS and HTML (Material-inspired styling). Supports English, Polish and German, keyboard navigation, accessibility features, and headless integration for React, Vue, or Next.js.
+Lightweight **monthly date picker** written in TypeScript, CSS and HTML with **macOS-inspired** styling, **light/dark mode** (system-aware), and CSS design tokens. Supports English, Polish and German, keyboard navigation, accessibility features, and headless integration for React, Vue, or Next.js.
 
 **If you have any questions or suggestions — look at my GitHub account and contact me!**
 
@@ -17,14 +17,14 @@ Lightweight **monthly date picker** written in TypeScript, CSS and HTML (Materia
 - **Previous / next month** — header buttons and keyboard arrows
 - **Year bounds** — navigation limited to years **1–9999**; buttons disabled at min/max
 - **Today** — highlighted day with `aria-current="date"`
-- **Weekends** — Saturday and Sunday cells styled differently (`.saturday`, `.sunday`)
+- **Weekends** — Saturday and Sunday cells styled differently (`.pun-saturday`, `.pun-sunday`)
 - **Multiple instances** — call `pickUpNewDate()` several times for separate widgets on one page
 
 ### Date selection
 
 - **`onDateSelect(date)`** — callback when a day is clicked (local `Date` object)
 - **`initialDate`** — open on a given month and pre-select that day
-- **Selected state** — visible highlight (`.selected`) and `aria-selected="true"`
+- **Selected state** — visible highlight (`.pun-selected`) and `aria-selected="true"`
 - **`getSelectedDate()`** — read the current selection (`null` if none)
 - **`goToDate(year, month, day?)`** — jump to a month; optionally select a day and fire `onDateSelect`
 
@@ -59,6 +59,13 @@ Lightweight **monthly date picker** written in TypeScript, CSS and HTML (Materia
 - Language dictionaries deep-frozen (`deepFreeze`) to prevent accidental mutation
 - DOM built with **`textContent`** and **`setAttribute`** only (no `innerHTML`)
 
+### Theming (v2)
+
+- **CSS variables** on `.pun-root` (`--pun-accent`, `--pun-surface`, weekend tokens, …) — override without forking the stylesheet
+- **Light / dark / auto** — `options.theme` (`"auto"` follows `prefers-color-scheme`; `"light"` / `"dark"` set `data-pun-theme` on the mount node)
+- **Namespaced classes** — `pun-` prefix avoids collisions with Tailwind, shadcn, etc.
+- **`classNames`** — optional extra classes on `root`, `table`, `navButton`, `dayButton`
+
 ### Distribution and TypeScript
 
 - **ESM**, **CommonJS**, **UMD** bundles plus **`pickupnewdate/style.css`**
@@ -67,7 +74,7 @@ Lightweight **monthly date picker** written in TypeScript, CSS and HTML (Materia
 
 ### Not included (see roadmap)
 
-Event CRUD, recurrence, iCal sync, notifications, shared calendars, range/time pickers, `minDate`/`maxDate`, configurable week start, RTL, dark theme, and touch swipe are **not** implemented yet. Planned items are listed in [FEATURE_BACKLOG.md](FEATURE_BACKLOG.md).
+Event CRUD, recurrence, iCal sync, notifications, shared calendars, range/time pickers, `minDate`/`maxDate`, configurable week start, RTL, and touch swipe are **not** implemented yet. Planned items are listed in [FEATURE_BACKLOG.md](FEATURE_BACKLOG.md).
 
 ## Installation
 
@@ -81,12 +88,12 @@ npm install pickupnewdate
 
 ### CDN (unpkg / jsDelivr)
 
-Pin a version in production (example: `1.0.0`):
+Pin a version in production (example: `2.0.0`):
 
 ```html
 <div id="calendar"></div>
-<link rel="stylesheet" href="https://unpkg.com/pickupnewdate@1.0.0/dist/pickupnewdate.css">
-<script src="https://unpkg.com/pickupnewdate@1.0.0/dist/pickupnewdate.umd.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/pickupnewdate@2.0.0/dist/pickupnewdate.css">
+<script src="https://unpkg.com/pickupnewdate@2.0.0/dist/pickupnewdate.umd.js"></script>
 <script>
     pickUpNewDate("eng", "calendar", {
         onDateSelect: function (date) {
@@ -96,7 +103,7 @@ Pin a version in production (example: `1.0.0`):
 </script>
 ```
 
-jsDelivr uses the same paths, for example `https://cdn.jsdelivr.net/npm/pickupnewdate@1.0.0/dist/pickupnewdate.umd.js`.
+jsDelivr uses the same paths, for example `https://cdn.jsdelivr.net/npm/pickupnewdate@2.0.0/dist/pickupnewdate.umd.js`.
 
 The UMD bundle exposes:
 
@@ -140,9 +147,10 @@ Supported languages:
 ### ES modules
 
 ```js
+import "pickupnewdate/style.css";
 import { pickUpNewDate } from "pickupnewdate";
 
-pickUpNewDate("eng", "calendar");
+pickUpNewDate("eng", "calendar", { theme: "auto" });
 ```
 
 ### CommonJS
@@ -153,9 +161,39 @@ const { pickUpNewDate } = require("pickupnewdate");
 pickUpNewDate("eng", "calendar");
 ```
 
-### Next.js / Vue / React (headless integration)
+### Next.js / Vue / React
 
-Use the framework-agnostic model generator and render your own UI:
+**Built-in DOM calendar** — import CSS once, mount on the client:
+
+```tsx
+// app/layout.tsx or a client component
+import "pickupnewdate/style.css";
+import { pickUpNewDate } from "pickupnewdate";
+import { useEffect, useRef } from "react";
+
+export function CalendarWidget() {
+    const ref = useRef<HTMLDivElement>(null);
+    useEffect(() => {
+        if (!ref.current) return;
+        const instance = pickUpNewDate("eng", ref.current, {
+            theme: "auto",
+            classNames: { root: "my-app-calendar" }
+        });
+        return () => instance.destroy();
+    }, []);
+    return <div ref={ref} />;
+}
+```
+
+```css
+/* globals.css — align with your design system (e.g. shadcn) */
+.my-app-calendar {
+    --pun-accent: hsl(var(--primary));
+    --pun-radius: var(--radius);
+}
+```
+
+**Headless** — use the framework-agnostic model generator and render your own UI:
 
 ```js
 import { getCalendarViewModel } from "pickupnewdate";
@@ -165,6 +203,44 @@ const model = getCalendarViewModel(2026, 5, "eng");
 ```
 
 In SSR/non-browser environments, initialize DOM rendering only on the client, or pass a custom document adapter via `options.document`.
+
+### Theming and CSS tokens
+
+The mount element receives `pun-root`. Tokens are scoped to that node (not global `:root`).
+
+| Token | Purpose |
+|-------|---------|
+| `--pun-surface` | Calendar panel background |
+| `--pun-text` / `--pun-text-muted` | Primary and secondary text |
+| `--pun-accent` | Today ring, selected day, focus |
+| `--pun-weekend-sat-bg` / `--pun-weekend-sun-bg` | Weekend column backgrounds |
+| `--pun-weekday-bg` | Weekday header row |
+| `--pun-radius` | Panel corner radius |
+
+Override in your app:
+
+```css
+.pun-root {
+    --pun-accent: #5856d6;
+}
+```
+
+Force theme: `pickUpNewDate("eng", el, { theme: "dark" })` sets `data-pun-theme="dark"` on the mount node.
+
+### Migrating from 1.x to 2.0
+
+CSS class names are prefixed with `pun-`. Update custom selectors:
+
+| 1.x | 2.0 |
+|-----|-----|
+| `table.calendar` | `table.pun-calendar` |
+| `.calendarNavButton` | `.pun-navButton` |
+| `.calendarDayButton` | `.pun-dayButton` |
+| `.today` / `.selected` | `.pun-today` / `.pun-selected` |
+| `.saturday` / `.sunday` | `.pun-saturday` / `.pun-sunday` |
+| `.calendarLiveRegion` | `.pun-liveRegion` |
+
+Import path `pickupnewdate/style.css` is unchanged.
 
 ## API Reference
 
@@ -219,6 +295,10 @@ In SSR/non-browser environments, initialize DOM rendering only on the client, or
 | `onMonthChange` | `(year: number, month: number) => void` | Called after month changes |
 | `initialDate` | `Date` | Initial visible month and selected day |
 | `document` | `DocumentAdapter` | Custom `getElementById` / `createElement` for SSR or tests |
+| `theme` | `"light"` \| `"dark"` \| `"auto"` | Color scheme (`"auto"` default; uses OS preference unless forced) |
+| `classNames` | `Partial<Record<"root" \| "table" \| "navButton" \| "dayButton", string>>` | Extra CSS classes merged with library classes |
+
+Exported types: `CalendarTheme`, `CalendarClassNames`.
 
 TypeScript types are published from `dist/index.d.ts` after `npm run build`.
 

--- a/calendar.test.ts
+++ b/calendar.test.ts
@@ -118,7 +118,7 @@ test("navigation does not move below minimum year", () => {
     calendar.prevMonth();
     assert.equal(calendar.currentYear, 1);
     assert.equal(calendar.currentMonth, 1);
-    const navButtons = root.querySelectorAll("button.calendarNavButton");
+    const navButtons = root.querySelectorAll("button.pun-navButton");
     assert.equal(navButtons[0]?.disabled, true);
 });
 
@@ -127,7 +127,7 @@ test("navigation does not move above maximum year", () => {
     calendar.nextMonth();
     assert.equal(calendar.currentYear, 9999);
     assert.equal(calendar.currentMonth, 12);
-    const navButtons = root.querySelectorAll("button.calendarNavButton");
+    const navButtons = root.querySelectorAll("button.pun-navButton");
     assert.equal(navButtons[navButtons.length - 1]?.disabled, true);
 });
 
@@ -140,7 +140,7 @@ test("selectDate stores selection and marks selected day in DOM", () => {
     assert.equal(selected?.getMonth(), 1);
     assert.equal(selected?.getDate(), 15);
 
-    const selectedButton = root.querySelector("button.calendarDayButton.selected");
+    const selectedButton = root.querySelector("button.pun-dayButton.pun-selected");
     assert.ok(selectedButton);
     assert.equal(selectedButton?.getAttribute("aria-selected"), "true");
     assert.equal(selectedButton?.textContent, "15");
@@ -188,7 +188,7 @@ test("onDateSelect callback receives local calendar date", () => {
 
 test("render includes aria-live region for month changes", () => {
     const { calendar, root } = createCalendarInstance(2024, 2);
-    const liveRegion = root.querySelector(".calendarLiveRegion");
+    const liveRegion = root.querySelector(".pun-liveRegion");
     assert.ok(liveRegion);
     assert.equal(liveRegion?.getAttribute("aria-live"), "polite");
     calendar.nextMonth();
@@ -208,6 +208,43 @@ test("getMonthGrid uses correct weekday for year 50 (not mapped to 1950)", () =>
         [21, 22, 23, 24, 25, 26, 27],
         [28, null, null, null, null, null, null]
     ]);
+});
+
+test("applyRootStyling adds pun-root and theme attribute", () => {
+    const mockDocument = createMockDocument();
+    const root = mockDocument.createElement("div");
+    root.id = "calendar-root";
+    mockDocument.registerElement(root);
+
+    pickUpNewDate("eng", "calendar-root", {
+        document: mockDocument,
+        theme: "dark",
+        classNames: { root: "my-calendar" }
+    });
+
+    assert.equal(root.classList.contains("pun-root"), true);
+    assert.equal(root.classList.contains("my-calendar"), true);
+    assert.equal(root.getAttribute("data-pun-theme"), "dark");
+
+    const autoRoot = mockDocument.createElement("div");
+    autoRoot.id = "calendar-auto";
+    mockDocument.registerElement(autoRoot);
+    pickUpNewDate("eng", "calendar-auto", { document: mockDocument, theme: "auto" });
+    assert.equal(autoRoot.getAttribute("data-pun-theme"), null);
+});
+
+test("pickUpNewDate validates theme option", () => {
+    const mockDocument = createMockDocument();
+    const root = mockDocument.createElement("div");
+    root.id = "calendar-root";
+    mockDocument.registerElement(root);
+
+    assert.throws(() => {
+        pickUpNewDate("eng", "calendar-root", {
+            document: mockDocument,
+            theme: "neon" as "auto"
+        });
+    }, /options.theme must be/);
 });
 
 test("createLocalDate preserves years 1 through 99", () => {
@@ -285,13 +322,13 @@ class MockElement {
         this.attributes.set(name, value);
         if (name === "aria-selected") {
             if (value === "true") {
-                this.classList.add("selected");
+                this.classList.add("pun-selected");
             } else {
-                this.classList.remove("selected");
+                this.classList.remove("pun-selected");
             }
         }
         if (name === "aria-current" && value === "date") {
-            this.classList.add("today");
+            this.classList.add("pun-today");
         }
         if (name === "aria-disabled" && value === "true") {
             this.disabled = true;
@@ -300,6 +337,10 @@ class MockElement {
 
     getAttribute(name: string): string | null {
         return this.attributes.get(name) ?? null;
+    }
+
+    removeAttribute(name: string): void {
+        this.attributes.delete(name);
     }
 
     appendChild(child: MockElement): MockElement {
@@ -324,33 +365,33 @@ class MockElement {
     }
 
     querySelector(selector: string): MockElement | null {
-        if (selector.startsWith("button.calendarDayButton[data-day=")) {
+        if (selector.startsWith("button.pun-dayButton[data-day=")) {
             const match = /data-day="(\d+)"/.exec(selector);
             const day = match?.[1];
             return this.findInTree(
-                (element) => element.classList.contains("calendarDayButton") && element.dataset.day === day
+                (element) => element.classList.contains("pun-dayButton") && element.dataset.day === day
             );
         }
 
-        if (selector === "button.calendarDayButton.selected") {
+        if (selector === "button.pun-dayButton.pun-selected") {
             return this.findInTree(
                 (element) =>
-                    element.classList.contains("calendarDayButton") && element.classList.contains("selected")
+                    element.classList.contains("pun-dayButton") && element.classList.contains("pun-selected")
             );
         }
 
-        if (selector === ".calendarLiveRegion") {
-            return this.findInTree((element) => element.classList.contains("calendarLiveRegion"));
+        if (selector === ".pun-liveRegion") {
+            return this.findInTree((element) => element.classList.contains("pun-liveRegion"));
         }
 
         return null;
     }
 
     querySelectorAll(selector: string): MockElement[] {
-        if (selector === "button.calendarNavButton") {
+        if (selector === "button.pun-navButton") {
             const matches: MockElement[] = [];
             this.walkTree((element) => {
-                if (element.classList.contains("calendarNavButton")) {
+                if (element.classList.contains("pun-navButton")) {
                     matches.push(element);
                 }
             });

--- a/calendar.test.ts
+++ b/calendar.test.ts
@@ -158,6 +158,8 @@ test("destroy clears root and prevents further usage", () => {
     const { calendar, root } = createCalendarInstance(2024, 3);
     calendar.destroy();
     assert.equal(root.childElementCount, 0);
+    assert.equal(root.classList.contains("pun-root"), false);
+    assert.equal(root.getAttribute("data-pun-theme"), null);
     assert.throws(() => {
         calendar.nextMonth();
     }, /destroyed/);
@@ -320,16 +322,6 @@ class MockElement {
 
     setAttribute(name: string, value: string): void {
         this.attributes.set(name, value);
-        if (name === "aria-selected") {
-            if (value === "true") {
-                this.classList.add("pun-selected");
-            } else {
-                this.classList.remove("pun-selected");
-            }
-        }
-        if (name === "aria-current" && value === "date") {
-            this.classList.add("pun-today");
-        }
         if (name === "aria-disabled" && value === "true") {
             this.disabled = true;
         }

--- a/index.html
+++ b/index.html
@@ -5,14 +5,31 @@
     <title>Pick Up New Date Calendar | tomaszmiller.pl</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="light dark">
     <link href="dist/pickupnewdate.css" rel="stylesheet" />
+    <style>
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: #f5f5f7;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            body {
+                background: #1c1c1e;
+            }
+        }
+    </style>
 </head>
 
 <body>
     <div id="calendar"></div>
     <script src="dist/pickupnewdate.umd.js"></script>
     <script>
-        pickUpNewDate("eng", "calendar");
+        pickUpNewDate("eng", "calendar", { theme: "auto" });
     </script>
 </body>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pickupnewdate",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pickupnewdate",
-      "version": "1.1.1",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-terser": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pickupnewdate",
-  "version": "1.1.1",
-  "description": "Simple multilingual calendar library for browsers and Node.js.",
+  "version": "2.0.0",
+  "description": "Simple multilingual calendar library with macOS-inspired theming, light/dark mode, and framework-friendly APIs.",
   "type": "module",
   "main": "./dist/pickupnewdate.cjs",
   "module": "./dist/pickupnewdate.esm.js",

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -44,6 +44,18 @@ export class Calendar {
             throw new Error('PickUpNewDate: options.theme must be "light", "dark", or "auto".');
         }
 
+        if (typeof this.options.classNames !== "undefined") {
+            const cn = this.options.classNames;
+            if (typeof cn !== "object" || cn === null || Array.isArray(cn)) {
+                throw new Error("PickUpNewDate: options.classNames must be an object.");
+            }
+            for (const key of ["root", "table", "navButton", "dayButton"] as const) {
+                if (typeof cn[key] !== "undefined" && typeof cn[key] !== "string") {
+                    throw new Error(`PickUpNewDate: options.classNames.${key} must be a string.`);
+                }
+            }
+        }
+
         this.root = this.resolveRoot(area);
         this.applyRootStyling();
 
@@ -123,6 +135,7 @@ export class Calendar {
             return;
         }
         this.root.removeEventListener("keydown", this.handleRootKeydown, true);
+        this.removeRootStyling();
         this.root.replaceChildren();
         this.liveRegion = null;
         this.destroyed = true;
@@ -343,60 +356,34 @@ export class Calendar {
     }
 
     private handleDayKey(key: string, currentDay: number): boolean {
-        const weeks = getCalendarViewModel(this.currentYear, this.currentMonth, this.lang).weeks;
-        let row = -1;
-        let col = -1;
-
-        weeks.forEach((week, rowIndex) => {
-            week.forEach((day, colIndex) => {
-                if (day === currentDay) {
-                    row = rowIndex;
-                    col = colIndex;
-                }
-            });
-        });
-
-        if (row < 0 || col < 0) {
-            return false;
-        }
-
-        let dRow = 0;
-        let dCol = 0;
+        const totalDays = getDaysInMonth(this.currentYear, this.currentMonth);
+        let nextDay: number;
 
         switch (key) {
             case "ArrowLeft":
-                dCol = -1;
+                nextDay = currentDay - 1;
                 break;
             case "ArrowRight":
-                dCol = 1;
+                nextDay = currentDay + 1;
                 break;
             case "ArrowUp":
-                dRow = -1;
+                nextDay = currentDay - 7;
                 break;
             case "ArrowDown":
-                dRow = 1;
+                nextDay = currentDay + 7;
                 break;
             default:
                 return false;
         }
-        let nextRow = row;
-        let nextCol = col;
-        const maxSteps = weeks.length * 7;
-        for (let step = 0; step < maxSteps; step += 1) {
-            nextRow += dRow;
-            nextCol += dCol;
-            if (nextCol < 0 || nextCol > 6 || nextRow < 0 || nextRow >= weeks.length) {
-                return false;
-            }
-            const nextDay = weeks[nextRow]?.[nextCol];
-            if (nextDay !== null && nextDay !== undefined) {
-                const button = this.root.querySelector<HTMLButtonElement>(
-                    `button.pun-dayButton[data-day="${nextDay}"]`
-                );
-                button?.focus();
-                return true;
-            }
+
+        if (nextDay >= 1 && nextDay <= totalDays) {
+            const button = this.root.querySelector<HTMLButtonElement>(
+                `button.pun-dayButton[data-day="${nextDay}"]`
+            );
+            button?.focus();
+            return true;
         }
+
         return false;
     }
 
@@ -472,15 +459,20 @@ export class Calendar {
         );
     }
 
+    private rootClassNameTokens(): string[] {
+        const extraRoot = this.options.classNames?.root;
+        return extraRoot ? extraRoot.split(/\s+/).filter(Boolean) : [];
+    }
+
+    private removeRootStyling(): void {
+        this.root.classList.remove("pun-root");
+        this.rootClassNameTokens().forEach((token) => this.root.classList.remove(token));
+        this.root.removeAttribute("data-pun-theme");
+    }
+
     private applyRootStyling(): void {
         this.root.classList.add("pun-root");
-        const extraRoot = this.options.classNames?.root;
-        if (extraRoot) {
-            extraRoot
-                .split(/\s+/)
-                .filter(Boolean)
-                .forEach((token) => this.root.classList.add(token));
-        }
+        this.rootClassNameTokens().forEach((token) => this.root.classList.add(token));
 
         const theme: CalendarTheme = this.options.theme ?? "auto";
         if (theme === "auto") {

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -1,5 +1,5 @@
 import { createLocalDate, getCalendarViewModel, getDaysInMonth, resolveLanguage, validateMonth, validateYear } from "./core.js";
-import type { CalendarOptions, CalendarRoot, DocumentAdapter } from "./types.js";
+import type { CalendarOptions, CalendarRoot, CalendarTheme, DocumentAdapter } from "./types.js";
 import { MAX_YEAR, MIN_YEAR } from "./types.js";
 
 function isCalendarRoot(value: unknown): value is CalendarRoot {
@@ -37,7 +37,15 @@ export class Calendar {
             throw new Error("PickUpNewDate: options.onMonthChange must be a function.");
         }
 
+        if (
+            typeof this.options.theme !== "undefined" &&
+            !["light", "dark", "auto"].includes(this.options.theme)
+        ) {
+            throw new Error('PickUpNewDate: options.theme must be "light", "dark", or "auto".');
+        }
+
         this.root = this.resolveRoot(area);
+        this.applyRootStyling();
 
         const today = new Date();
         this.currentMonth = today.getMonth() + 1;
@@ -174,28 +182,28 @@ export class Calendar {
         const navRow = this.documentRef.createElement("tr");
         const daysRow = this.documentRef.createElement("tr");
 
-        table.className = "calendar";
+        table.className = this.mergeClassName("pun-calendar", this.options.classNames?.table);
         table.setAttribute("role", "grid");
         table.setAttribute("aria-label", `${labels.calendar}: ${viewModel.monthName} ${viewModel.year}`);
 
         const caption = this.documentRef.createElement("caption");
-        caption.className = "calendarCaption";
+        caption.className = "pun-caption";
         caption.textContent = monthYearLabel;
         table.appendChild(caption);
 
         const prevCell = this.documentRef.createElement("td");
-        prevCell.className = "monthHeader";
+        prevCell.className = "pun-monthHeader";
         prevCell.appendChild(
             this.createNavigationButton("‹", labels.previousMonth, () => this.prevMonth(), !this.canGoPrev())
         );
 
         const titleCell = this.documentRef.createElement("td");
-        titleCell.className = "monthHeader";
+        titleCell.className = "pun-monthHeader";
         titleCell.colSpan = 5;
         titleCell.textContent = monthYearLabel;
 
         const nextCell = this.documentRef.createElement("td");
-        nextCell.className = "monthHeader";
+        nextCell.className = "pun-monthHeader";
         nextCell.appendChild(
             this.createNavigationButton("›", labels.nextMonth, () => this.nextMonth(), !this.canGoNext())
         );
@@ -207,7 +215,7 @@ export class Calendar {
 
         dayNames.forEach((dayName) => {
             const headerCell = this.documentRef.createElement("th");
-            headerCell.className = "weekDayName";
+            headerCell.className = "pun-weekDayName";
             headerCell.scope = "col";
             headerCell.textContent = dayName;
             daysRow.appendChild(headerCell);
@@ -222,16 +230,16 @@ export class Calendar {
                 cell.setAttribute("role", "gridcell");
 
                 if (day !== null) {
-                    cell.classList.add("currentMonth");
+                    cell.classList.add("pun-dayCell");
                     if (index === 5) {
-                        cell.classList.add("saturday");
+                        cell.classList.add("pun-saturday");
                     }
                     if (index === 6) {
-                        cell.classList.add("sunday");
+                        cell.classList.add("pun-sunday");
                     }
                     cell.appendChild(this.createDayButton(day));
                 } else {
-                    cell.classList.add("emptyDay");
+                    cell.classList.add("pun-emptyDay");
                     cell.setAttribute("aria-hidden", "true");
                 }
 
@@ -305,7 +313,7 @@ export class Calendar {
     private ensureLiveRegion(): void {
         if (!this.liveRegion) {
             this.liveRegion = this.documentRef.createElement("div");
-            this.liveRegion.className = "calendarLiveRegion";
+            this.liveRegion.className = "pun-liveRegion";
             this.liveRegion.setAttribute("aria-live", "polite");
             this.liveRegion.setAttribute("aria-atomic", "true");
         }
@@ -317,7 +325,7 @@ export class Calendar {
             return;
         }
 
-        if (target.classList.contains("calendarDayButton")) {
+        if (target.classList.contains("pun-dayButton")) {
             const day = Number(target.dataset.day);
             if (Number.isInteger(day) && this.handleDayKey(event.key, day)) {
                 event.preventDefault();
@@ -383,7 +391,7 @@ export class Calendar {
             const nextDay = weeks[nextRow]?.[nextCol];
             if (nextDay !== null && nextDay !== undefined) {
                 const button = this.root.querySelector<HTMLButtonElement>(
-                    `button.calendarDayButton[data-day="${nextDay}"]`
+                    `button.pun-dayButton[data-day="${nextDay}"]`
                 );
                 button?.focus();
                 return true;
@@ -400,7 +408,7 @@ export class Calendar {
     ): HTMLButtonElement {
         const button = this.documentRef.createElement("button");
         button.type = "button";
-        button.className = "calendarNavButton";
+        button.className = this.mergeClassName("pun-navButton", this.options.classNames?.navButton);
         button.setAttribute("aria-label", label);
         button.disabled = disabled;
         if (disabled) {
@@ -409,7 +417,7 @@ export class Calendar {
         button.addEventListener("click", action);
 
         const iconNode = this.documentRef.createElement("span");
-        iconNode.className = "calendarNavIcon";
+        iconNode.className = "pun-navIcon";
         iconNode.setAttribute("aria-hidden", "true");
         iconNode.textContent = icon;
         button.appendChild(iconNode);
@@ -420,7 +428,7 @@ export class Calendar {
     private createDayButton(day: number): HTMLButtonElement {
         const button = this.documentRef.createElement("button");
         button.type = "button";
-        button.className = "calendarDayButton";
+        button.className = this.mergeClassName("pun-dayButton", this.options.classNames?.dayButton);
         button.textContent = String(day);
         button.dataset.day = String(day);
         button.setAttribute(
@@ -435,12 +443,12 @@ export class Calendar {
             this.currentYear === today.getFullYear();
 
         if (isToday) {
-            button.classList.add("today");
+            button.classList.add("pun-today");
             button.setAttribute("aria-current", "date");
         }
 
         if (this.isSelectedDay(day)) {
-            button.classList.add("selected");
+            button.classList.add("pun-selected");
             button.setAttribute("aria-selected", "true");
         } else {
             button.setAttribute("aria-selected", "false");
@@ -462,6 +470,31 @@ export class Calendar {
             this.selectedDate.getMonth() + 1 === this.currentMonth &&
             this.selectedDate.getDate() === day
         );
+    }
+
+    private applyRootStyling(): void {
+        this.root.classList.add("pun-root");
+        const extraRoot = this.options.classNames?.root;
+        if (extraRoot) {
+            extraRoot
+                .split(/\s+/)
+                .filter(Boolean)
+                .forEach((token) => this.root.classList.add(token));
+        }
+
+        const theme: CalendarTheme = this.options.theme ?? "auto";
+        if (theme === "auto") {
+            this.root.removeAttribute("data-pun-theme");
+        } else {
+            this.root.setAttribute("data-pun-theme", theme);
+        }
+    }
+
+    private mergeClassName(base: string, extra?: string): string {
+        if (!extra) {
+            return base;
+        }
+        return `${base} ${extra}`.trim();
     }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,11 +31,20 @@ export type CalendarRoot = HTMLElement & {
     replaceChildren(...nodes: (Node | string)[]): void;
 };
 
+export type CalendarTheme = "light" | "dark" | "auto";
+
+export type CalendarClassNames = Partial<
+    Record<"root" | "table" | "navButton" | "dayButton", string>
+>;
+
 export interface CalendarOptions {
     onDateSelect?: (date: Date) => void;
     onMonthChange?: (year: number, month: number) => void;
     initialDate?: Date;
     document?: DocumentAdapter;
+    /** @default "auto" — follows OS; use "light" or "dark" to force via data-pun-theme */
+    theme?: CalendarTheme;
+    classNames?: CalendarClassNames;
 }
 
 export interface CalendarViewModel {

--- a/style.css
+++ b/style.css
@@ -37,10 +37,8 @@
     --pun-header-line: 40px;
     --pun-padding: 12px;
     --pun-margin: 24px;
-}
 
-@media (prefers-color-scheme: dark) {
-    .pun-root:not([data-pun-theme="light"]) {
+    &[data-pun-theme="dark"] {
         --pun-bg: #1c1c1e;
         --pun-surface: #2c2c2e;
         --pun-border: rgba(255, 255, 255, 0.1);
@@ -62,29 +60,31 @@
         --pun-nav-bg-active: rgba(255, 255, 255, 0.14);
         --pun-focus: #0a84ff;
     }
-}
 
-.pun-root[data-pun-theme="dark"] {
-    --pun-bg: #1c1c1e;
-    --pun-surface: #2c2c2e;
-    --pun-border: rgba(255, 255, 255, 0.1);
-    --pun-shadow: 0 8px 32px rgba(0, 0, 0, 0.45);
-    --pun-text: #f5f5f7;
-    --pun-text-muted: #98989d;
-    --pun-accent: #0a84ff;
-    --pun-accent-hover: #409cff;
-    --pun-weekday-bg: #3a3a3c;
-    --pun-weekday-text: #f5f5f7;
-    --pun-weekend-sat-bg: #3d3520;
-    --pun-weekend-sat-text: #ffd54f;
-    --pun-weekend-sun-bg: #3d2430;
-    --pun-weekend-sun-text: #f48fb1;
-    --pun-day-bg: #3a3a3c;
-    --pun-day-text: var(--pun-text);
-    --pun-day-hover: rgba(10, 132, 255, 0.2);
-    --pun-nav-bg-hover: rgba(255, 255, 255, 0.08);
-    --pun-nav-bg-active: rgba(255, 255, 255, 0.14);
-    --pun-focus: #0a84ff;
+    @media (prefers-color-scheme: dark) {
+        &:not([data-pun-theme="light"]) {
+            --pun-bg: #1c1c1e;
+            --pun-surface: #2c2c2e;
+            --pun-border: rgba(255, 255, 255, 0.1);
+            --pun-shadow: 0 8px 32px rgba(0, 0, 0, 0.45);
+            --pun-text: #f5f5f7;
+            --pun-text-muted: #98989d;
+            --pun-accent: #0a84ff;
+            --pun-accent-hover: #409cff;
+            --pun-weekday-bg: #3a3a3c;
+            --pun-weekday-text: #f5f5f7;
+            --pun-weekend-sat-bg: #3d3520;
+            --pun-weekend-sat-text: #ffd54f;
+            --pun-weekend-sun-bg: #3d2430;
+            --pun-weekend-sun-text: #f48fb1;
+            --pun-day-bg: #3a3a3c;
+            --pun-day-text: var(--pun-text);
+            --pun-day-hover: rgba(10, 132, 255, 0.2);
+            --pun-nav-bg-hover: rgba(255, 255, 255, 0.08);
+            --pun-nav-bg-active: rgba(255, 255, 255, 0.14);
+            --pun-focus: #0a84ff;
+        }
+    }
 }
 
 table.pun-calendar {
@@ -250,7 +250,7 @@ table.pun-calendar td.pun-dayCell .pun-dayButton.pun-selected:hover {
     background-color: var(--pun-accent-hover);
 }
 
-table.pun-calendar td.pun-dayCell:active .pun-dayButton:not(.pun-selected) {
+table.pun-calendar td.pun-dayCell .pun-dayButton:not(.pun-selected):active {
     box-shadow: var(--pun-day-active-shadow);
 }
 

--- a/style.css
+++ b/style.css
@@ -1,148 +1,260 @@
-table.calendar {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-    border-radius: 20px;
-    box-shadow: 0 10px 30px 1px #BDBDBD;
-    padding: 10px;
-    margin: 30px;
-    cursor: default;
-    border-collapse: separate;
-    border-spacing: 7px;
-    background-color: #fff;
+.pun-root {
+    color-scheme: light dark;
+    font-family: var(--pun-font);
+    --pun-font: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    --pun-radius: 12px;
+    --pun-radius-sm: 8px;
+    --pun-radius-pill: 999px;
+    --pun-bg: #f5f5f7;
+    --pun-surface: #ffffff;
+    --pun-border: rgba(0, 0, 0, 0.08);
+    --pun-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+    --pun-text: #1d1d1f;
+    --pun-text-muted: #6e6e73;
+    --pun-accent: #007aff;
+    --pun-accent-hover: #0056b3;
+    --pun-today-ring: var(--pun-accent);
+    --pun-selected-bg: var(--pun-accent);
+    --pun-selected-text: #ffffff;
+    --pun-weekday-bg: #e8e8ed;
+    --pun-weekday-text: #1d1d1f;
+    --pun-weekend-sat-bg: #fff8e1;
+    --pun-weekend-sat-text: #5d4e00;
+    --pun-weekend-sun-bg: #fce4ec;
+    --pun-weekend-sun-text: #880e4f;
+    --pun-day-bg: #f0f0f5;
+    --pun-day-text: var(--pun-text);
+    --pun-day-hover: rgba(0, 122, 255, 0.12);
+    --pun-day-active-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+    --pun-nav-bg: transparent;
+    --pun-nav-bg-hover: rgba(0, 0, 0, 0.06);
+    --pun-nav-bg-active: rgba(0, 0, 0, 0.1);
+    --pun-nav-text: var(--pun-text-muted);
+    --pun-nav-disabled-opacity: 0.35;
+    --pun-focus: #007aff;
+    --pun-spacing: 6px;
+    --pun-cell-min: 40px;
+    --pun-header-line: 40px;
+    --pun-padding: 12px;
+    --pun-margin: 24px;
 }
 
-table.calendar:focus {
-    outline: 3px solid #64B5F6;
+@media (prefers-color-scheme: dark) {
+    .pun-root:not([data-pun-theme="light"]) {
+        --pun-bg: #1c1c1e;
+        --pun-surface: #2c2c2e;
+        --pun-border: rgba(255, 255, 255, 0.1);
+        --pun-shadow: 0 8px 32px rgba(0, 0, 0, 0.45);
+        --pun-text: #f5f5f7;
+        --pun-text-muted: #98989d;
+        --pun-accent: #0a84ff;
+        --pun-accent-hover: #409cff;
+        --pun-weekday-bg: #3a3a3c;
+        --pun-weekday-text: #f5f5f7;
+        --pun-weekend-sat-bg: #3d3520;
+        --pun-weekend-sat-text: #ffd54f;
+        --pun-weekend-sun-bg: #3d2430;
+        --pun-weekend-sun-text: #f48fb1;
+        --pun-day-bg: #3a3a3c;
+        --pun-day-text: var(--pun-text);
+        --pun-day-hover: rgba(10, 132, 255, 0.2);
+        --pun-nav-bg-hover: rgba(255, 255, 255, 0.08);
+        --pun-nav-bg-active: rgba(255, 255, 255, 0.14);
+        --pun-focus: #0a84ff;
+    }
+}
+
+.pun-root[data-pun-theme="dark"] {
+    --pun-bg: #1c1c1e;
+    --pun-surface: #2c2c2e;
+    --pun-border: rgba(255, 255, 255, 0.1);
+    --pun-shadow: 0 8px 32px rgba(0, 0, 0, 0.45);
+    --pun-text: #f5f5f7;
+    --pun-text-muted: #98989d;
+    --pun-accent: #0a84ff;
+    --pun-accent-hover: #409cff;
+    --pun-weekday-bg: #3a3a3c;
+    --pun-weekday-text: #f5f5f7;
+    --pun-weekend-sat-bg: #3d3520;
+    --pun-weekend-sat-text: #ffd54f;
+    --pun-weekend-sun-bg: #3d2430;
+    --pun-weekend-sun-text: #f48fb1;
+    --pun-day-bg: #3a3a3c;
+    --pun-day-text: var(--pun-text);
+    --pun-day-hover: rgba(10, 132, 255, 0.2);
+    --pun-nav-bg-hover: rgba(255, 255, 255, 0.08);
+    --pun-nav-bg-active: rgba(255, 255, 255, 0.14);
+    --pun-focus: #0a84ff;
+}
+
+table.pun-calendar {
+    border-radius: var(--pun-radius);
+    box-shadow: var(--pun-shadow);
+    padding: var(--pun-padding);
+    margin: var(--pun-margin);
+    cursor: default;
+    border-collapse: separate;
+    border-spacing: var(--pun-spacing);
+    background-color: var(--pun-surface);
+    border: 1px solid var(--pun-border);
+    color: var(--pun-text);
+}
+
+table.pun-calendar:focus {
+    outline: 3px solid var(--pun-focus);
     outline-offset: 4px;
 }
 
-table.calendar td, table.calendar th {
+table.pun-calendar td,
+table.pun-calendar th {
     border: 0;
-    border-radius: 6px;
-    min-width: 40px;
+    border-radius: var(--pun-radius-sm);
+    min-width: var(--pun-cell-min);
     text-align: center;
     vertical-align: middle;
     padding: 0;
     margin: 0;
 }
 
-table.calendar td.monthHeader {
-    font-weight: bold;
-    font-size: 18px;
-    line-height: 40px;
+table.pun-calendar td.pun-monthHeader {
+    font-weight: 600;
+    font-size: 17px;
+    line-height: var(--pun-header-line);
+    color: var(--pun-text);
 }
 
-table.calendar td.monthHeader:first-child, table.calendar td.monthHeader:last-child {
-    border-radius: 20px;
+table.pun-calendar td.pun-monthHeader:first-child,
+table.pun-calendar td.pun-monthHeader:last-child {
+    border-radius: var(--pun-radius-sm);
 }
 
-table.calendar td.monthHeader .calendarNavButton {
+table.pun-calendar td.pun-monthHeader .pun-navButton {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 40px;
-    height: 40px;
+    width: var(--pun-header-line);
+    height: var(--pun-header-line);
     border: 0;
     padding: 0;
     cursor: pointer;
-    border-radius: 20px;
-    background-color: #64B5F6;
-    box-shadow: 0 2px 6px #BDBDBD;
-    transition: box-shadow .1s, transform .1s;
+    border-radius: var(--pun-radius-sm);
+    background-color: var(--pun-nav-bg);
+    color: var(--pun-nav-text);
+    transition: background-color 0.15s ease, transform 0.1s ease;
 }
 
-table.calendar td.monthHeader .calendarNavButton .calendarNavIcon {
-    width: 40px;
-    line-height: 40px;
-    font-size: 24px;
+table.pun-calendar td.pun-monthHeader .pun-navButton:hover:not(:disabled) {
+    background-color: var(--pun-nav-bg-hover);
+    color: var(--pun-text);
 }
 
-table.calendar td.monthHeader .calendarNavButton:active {
-    box-shadow: 0 5px 8px #BDBDBD;
+table.pun-calendar td.pun-monthHeader .pun-navButton .pun-navIcon {
+    width: var(--pun-header-line);
+    line-height: var(--pun-header-line);
+    font-size: 22px;
+    font-weight: 300;
+}
+
+table.pun-calendar td.pun-monthHeader .pun-navButton:active:not(:disabled) {
+    background-color: var(--pun-nav-bg-active);
     transform: translateY(1px);
 }
 
-table.calendar td.monthHeader .calendarNavButton:disabled {
+table.pun-calendar td.pun-monthHeader .pun-navButton:disabled {
     cursor: not-allowed;
-    opacity: 0.45;
-    box-shadow: none;
+    opacity: var(--pun-nav-disabled-opacity);
     transform: none;
 }
 
-table.calendar td.monthHeader .calendarNavButton:focus-visible,
-table.calendar td.currentMonth .calendarDayButton:focus-visible {
-    outline: 2px solid #1B5E20;
+table.pun-calendar td.pun-monthHeader .pun-navButton:focus-visible,
+table.pun-calendar td.pun-dayCell .pun-dayButton:focus-visible {
+    outline: 2px solid var(--pun-focus);
     outline-offset: 2px;
 }
 
-table.calendar th.weekDayName {
-    border-radius: 20px;
-    background-color: #1B5E20;
-    color: white;
-    font-weight: bold;
-    line-height: 40px;
-    box-shadow: 0 2px 6px #BDBDBD;
+table.pun-calendar th.pun-weekDayName {
+    border-radius: var(--pun-radius-sm);
+    background-color: var(--pun-weekday-bg);
+    color: var(--pun-weekday-text);
+    font-weight: 600;
+    font-size: 13px;
+    line-height: var(--pun-header-line);
 }
 
-table.calendar th.weekDayName:nth-child(6) {
-    background-color: #F57F17;
+table.pun-calendar th.pun-weekDayName:nth-child(6) {
+    background-color: var(--pun-weekend-sat-bg);
+    color: var(--pun-weekend-sat-text);
 }
 
-table.calendar th.weekDayName:last-child {
-    background-color: #880E4F;
+table.pun-calendar th.pun-weekDayName:last-child {
+    background-color: var(--pun-weekend-sun-bg);
+    color: var(--pun-weekend-sun-text);
 }
 
-table.calendar td.currentMonth {
-    border-radius: 20px;
-    background-color: #81C784;
-    line-height: 40px;
-    box-shadow: 0 2px 6px #BDBDBD;
+table.pun-calendar td.pun-dayCell {
+    border-radius: var(--pun-radius-sm);
+    background-color: var(--pun-day-bg);
+    color: var(--pun-day-text);
+    line-height: var(--pun-header-line);
 }
 
-table.calendar td.currentMonth.saturday {
-    background-color: #FFF59D;
+table.pun-calendar td.pun-dayCell.pun-saturday {
+    background-color: var(--pun-weekend-sat-bg);
+    color: var(--pun-weekend-sat-text);
 }
 
-table.calendar td.currentMonth.sunday {
-    background-color: #F48FB1;
+table.pun-calendar td.pun-dayCell.pun-sunday {
+    background-color: var(--pun-weekend-sun-bg);
+    color: var(--pun-weekend-sun-text);
 }
 
-table.calendar td.currentMonth .calendarDayButton {
+table.pun-calendar td.pun-emptyDay {
+    background: transparent;
+    pointer-events: none;
+}
+
+table.pun-calendar td.pun-dayCell .pun-dayButton {
     width: 100%;
-    min-height: 40px;
+    min-height: var(--pun-header-line);
     border: 0;
-    border-radius: 20px;
+    border-radius: var(--pun-radius-sm);
     background: transparent;
     color: inherit;
     font: inherit;
     cursor: pointer;
+    transition: background-color 0.12s ease;
 }
 
-table.calendar td.currentMonth .calendarDayButton.today {
-    background-color: #B39DDB;
+table.pun-calendar td.pun-dayCell .pun-dayButton:hover {
+    background-color: var(--pun-day-hover);
 }
 
-table.calendar td.currentMonth .calendarDayButton.selected {
-    background-color: #3949AB;
-    color: #fff;
-    font-weight: bold;
+table.pun-calendar td.pun-dayCell .pun-dayButton.pun-today {
+    box-shadow: inset 0 0 0 2px var(--pun-today-ring);
 }
 
-table.calendar td.currentMonth .calendarDayButton.today.selected {
-    background-color: #5E35B1;
+table.pun-calendar td.pun-dayCell .pun-dayButton.pun-selected {
+    background-color: var(--pun-selected-bg);
+    color: var(--pun-selected-text);
+    font-weight: 600;
+    box-shadow: none;
 }
 
-table.calendar tr:nth-child(1n+3) td.currentMonth:hover {
-    background-color: #FF7043;
-    color: #111;
-    cursor: pointer;
-    transition: box-shadow 0.1s;
+table.pun-calendar td.pun-dayCell .pun-dayButton.pun-today.pun-selected {
+    background-color: var(--pun-selected-bg);
+    color: var(--pun-selected-text);
+    box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.35);
 }
 
-table.calendar tr:nth-child(1n+3) td.currentMonth:active {
-    box-shadow: 0 5px 8px #BDBDBD;
+table.pun-calendar td.pun-dayCell .pun-dayButton.pun-selected:hover {
+    background-color: var(--pun-accent-hover);
 }
 
-.calendarLiveRegion {
+table.pun-calendar td.pun-dayCell:active .pun-dayButton:not(.pun-selected) {
+    box-shadow: var(--pun-day-active-shadow);
+}
+
+.pun-liveRegion {
     position: absolute;
     width: 1px;
     height: 1px;
@@ -154,13 +266,13 @@ table.calendar tr:nth-child(1n+3) td.currentMonth:active {
 }
 
 @media (prefers-reduced-motion: reduce) {
-    table.calendar td.monthHeader .calendarNavButton,
-    table.calendar tr:nth-child(1n + 3) td.currentMonth:hover {
+    table.pun-calendar td.pun-monthHeader .pun-navButton,
+    table.pun-calendar td.pun-dayCell .pun-dayButton {
         transition: none;
     }
 }
 
-.calendarCaption {
+.pun-caption {
     position: absolute;
     width: 1px;
     height: 1px;
@@ -172,33 +284,32 @@ table.calendar tr:nth-child(1n+3) td.currentMonth:active {
 }
 
 @media (max-width: 640px) {
-    table.calendar {
+    .pun-root {
+        --pun-cell-min: 0;
+        --pun-header-line: 32px;
+        --pun-padding: 8px;
+        --pun-margin: 12px;
+        --pun-spacing: 4px;
+    }
+
+    table.pun-calendar {
         width: calc(100% - 24px);
-        margin: 12px;
-        border-spacing: 4px;
-        padding: 8px;
     }
 
-    table.calendar td, table.calendar th {
-        min-width: 0;
-    }
-
-    table.calendar td.monthHeader,
-    table.calendar th.weekDayName,
-    table.calendar td.currentMonth .calendarDayButton {
+    table.pun-calendar td.pun-monthHeader,
+    table.pun-calendar th.pun-weekDayName,
+    table.pun-calendar td.pun-dayCell .pun-dayButton {
         font-size: 14px;
-        line-height: 32px;
-        min-height: 32px;
     }
 
-    table.calendar td.monthHeader .calendarNavButton {
-        width: 32px;
-        height: 32px;
+    table.pun-calendar td.pun-monthHeader .pun-navButton {
+        width: var(--pun-header-line);
+        height: var(--pun-header-line);
     }
 
-    table.calendar td.monthHeader .calendarNavButton .calendarNavIcon {
-        width: 32px;
-        line-height: 32px;
-        font-size: 20px;
+    table.pun-calendar td.pun-monthHeader .pun-navButton .pun-navIcon {
+        width: var(--pun-header-line);
+        line-height: var(--pun-header-line);
+        font-size: 18px;
     }
 }


### PR DESCRIPTION
This release adds a macOS-inspired default theme with light, dark, and auto modes, utilizing CSS custom properties. All CSS classes have been renamed with a `pun-` prefix to avoid conflicts. New features include options for additional class names and improved accessibility. The calendar now automatically applies root styling based on the selected theme. Breaking changes include updated class names in the API and documentation for migration from version 1.x to 2.0.